### PR TITLE
🐛 fix bug which cause reload LSP configurations endless

### DIFF
--- a/src/configurations/index.ts
+++ b/src/configurations/index.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 import { window, workspace } from "vscode";
 import { Context } from "../types";
-import { isDeepEqual } from "../utils";
+import { isSubset } from "../utils";
 import { ConfigurationManager } from "./services";
 import TEMPLATE from "./template";
 
@@ -104,8 +104,9 @@ export async function updateLanguageExtension(
     removeSymlinks(context);
 
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-    const rawLanguages = packageJson.contributes?.languages;
-    const rawGrammars = packageJson.contributes?.grammars;
+    const rawLanguages = packageJson.contributes
+      ?.languages as LanguageExtension[];
+    const rawGrammars = packageJson.contributes?.grammars as GrammarExtension[];
 
     let languageExtensions: LanguageExtension[] = [];
     let grammarExtensions: GrammarExtension[] = [];
@@ -174,8 +175,8 @@ export async function updateLanguageExtension(
     }
 
     const modified =
-      !isDeepEqual(languageExtensions, rawLanguages || []) ||
-      !isDeepEqual(grammarExtensions, rawGrammars || []);
+      !isSubset(languageExtensions, rawLanguages) ||
+      !isSubset(grammarExtensions, rawGrammars);
     if (modified) {
       packageJson.contributes.languages = languageExtensions;
       packageJson.contributes.grammars = grammarExtensions;

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -1,0 +1,47 @@
+import * as assert from "assert";
+import { isSubset } from "../utils";
+
+suite("Utils.isSubset Test Suite", () => {
+  test("primitives: left subset of right", () => {
+    const left = [1, 2];
+    const right = [2, 3, 1];
+    assert.strictEqual(isSubset(left, right), true);
+  });
+
+  test("primitives: left has new element", () => {
+    const left = [1, 4];
+    const right = [1, 2, 3];
+    assert.strictEqual(isSubset(left, right), false);
+  });
+
+  test("nested objects and arrays: deep equality", () => {
+    const left = [{ a: 1, b: [2, 3] }, [1, { x: 5 }]];
+    const right = [[1, { x: 5 }], { b: [2, 3], a: 1 }, { extra: true }];
+    assert.strictEqual(isSubset(left, right), true);
+  });
+
+  test("duplicates on left do not require multiplicity on right", () => {
+    const left = [1, 1, 2];
+    const right = [1, 2];
+    assert.strictEqual(isSubset(left, right), true);
+  });
+
+  test("empty left is subset of anything", () => {
+    const left: unknown[] = [];
+    const right = [1, 2, 3];
+    assert.strictEqual(isSubset(left, right), true);
+  });
+
+  test("keys with undefined values are ignored", () => {
+    const left = [{ k: undefined, j: 10 }];
+    const right = [{ j: 10 }];
+    assert.strictEqual(isSubset(left, right), true);
+  });
+
+  test("non-arrays return false", () => {
+    // @ts-expect-error: intent to pass wrong types to assert behavior
+    assert.strictEqual(isSubset(null, [1, 2]), false);
+    // @ts-expect-error: intent to pass wrong types to assert behavior
+    assert.strictEqual(isSubset([1, 2], null), false);
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export function isDeepEqual(arg1: unknown, arg2: unknown) {
+function isDeepEqual(arg1: unknown, arg2: unknown) {
   if (Array.isArray(arg1) && Array.isArray(arg2)) {
     if (arg1.length !== arg2.length) {
       return false;
@@ -23,8 +23,13 @@ export function isDeepEqual(arg1: unknown, arg2: unknown) {
     arg1 !== null &&
     arg2 !== null
   ) {
-    const keys1 = Object.keys(arg1);
-    const keys2 = Object.keys(arg2);
+    // a key is valid if the value is not undefined.
+    const keys1 = Object.entries(arg1)
+      .filter(([_, v]) => v !== undefined)
+      .map(([k, _]) => k);
+    const keys2 = Object.entries(arg2)
+      .filter(([_, v]) => v !== undefined)
+      .map(([k, _]) => k);
     if (keys1.length !== keys2.length) {
       return false;
     }
@@ -43,4 +48,30 @@ export function isDeepEqual(arg1: unknown, arg2: unknown) {
   } else {
     return arg1 === arg2;
   }
+}
+
+/**
+ * Returns true if every element of `left` appears in `right` (deep equality).
+ *
+ * Semantics: set-like membership (duplicates on `left` do not require matching
+ * multiplicity in `right`).
+ */
+export function isSubset(left: unknown[], right: unknown[]): boolean {
+  if (!Array.isArray(left) || !Array.isArray(right)) {
+    return false;
+  }
+
+  for (const l of left) {
+    let found = false;
+    for (const r of right) {
+      if (isDeepEqual(l, r)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return false;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
This fix the configuration comparison logic to behave

- Only consider configuration modified if any entries needs to be merged from configuration file into package.json
- When a object key has a undefined value, then ignore the key existence in the comparisons logic.